### PR TITLE
Fix masking bug iOS

### DIFF
--- a/ios/TextInputMask.swift
+++ b/ios/TextInputMask.swift
@@ -3,14 +3,16 @@ import InputMask
 
 @objc(RNTextInputMask)
 class TextInputMask: NSObject, RCTBridgeModule, MaskedTextFieldDelegateListener {
-    static func moduleName() -> String { return "TextInputMask" }
+    static func moduleName() -> String {
+        "TextInputMask"
+    }
     
     @objc static func requiresMainQueueSetup() -> Bool {
         true
     }
     
     var methodQueue: DispatchQueue {
-        return self.bridge.uiManager.methodQueue
+        bridge.uiManager.methodQueue
     }
     
     var bridge: RCTBridge!
@@ -30,12 +32,14 @@ class TextInputMask: NSObject, RCTBridgeModule, MaskedTextFieldDelegateListener 
     
     @objc(setMask:mask:autocomplete:autoskip:)
     func setMask(reactNode: NSNumber, mask: String, autocomplete: Bool, autoskip: Bool) {
-        self.bridge.uiManager.addUIBlock { (uiManager, viewRegistry) in
+        bridge.uiManager.addUIBlock { (uiManager, viewRegistry) in
             DispatchQueue.main.async {
                 guard let view = viewRegistry?[reactNode] as? RCTBaseTextInputView else { return }
                 let textView = view.backedTextInputView as! RCTUITextField
                 let maskedDelegate = MaskedTextFieldDelegate(primaryFormat: mask, autocomplete: autocomplete, autoskip: autoskip) { (view, value, complete) in
-                    textView.textInputDelegate?.textInputDidChange()
+                    if (complete) {
+                        textView.textInputDelegate?.textInputDidChange()
+                    }
                 }
                 maskedDelegate.listener = textView.delegate as? UITextFieldDelegate & MaskedTextFieldDelegateListener
                 let key = reactNode.stringValue


### PR DESCRIPTION
Firing textInputDidChange before masking is complete, causes it to try and mask partial value, causing issues with masking, specifically affecting masking dates i.e (YY/MM - `[00]{/}[00]`). Seems to affect all separators other than spaces for some reason.

Only calling when `complete` resolves the issue, with not side effects noticed