### PR TITLE
Fix onChange events

### DIFF
--- a/ios/TextInputMask.swift
+++ b/ios/TextInputMask.swift
@@ -36,10 +36,13 @@ class TextInputMask: NSObject, RCTBridgeModule, MaskedTextFieldDelegateListener 
             DispatchQueue.main.async {
                 guard let view = viewRegistry?[reactNode] as? RCTBaseTextInputView else { return }
                 let textView = view.backedTextInputView as! RCTUITextField
-                let maskedDelegate = MaskedTextFieldDelegate(primaryFormat: mask, autocomplete: autocomplete, autoskip: autoskip) { (view, value, complete) in
-                    if (complete) {
-                        textView.textInputDelegate?.textInputDidChange()
-                    }
+                let maskedDelegate = MaskedTextFieldDelegate(primaryFormat: mask, autocomplete: autocomplete, autoskip: autoskip) { (_, value, complete) in
+                    // trigger onChange directly to avoid trigger a second evaluation in native code (causes issue with some input masks like [00] {/} [00]
+                    view.onChange?([
+                        "text": RNMask.maskValue(text: value, format: mask),
+                        "target": view.reactTag,
+                        "eventCount": view.nativeEventCount,
+                    ])
                 }
                 maskedDelegate.listener = textView.delegate as? UITextFieldDelegate & MaskedTextFieldDelegateListener
                 let key = reactNode.stringValue


### PR DESCRIPTION
When using a mask like `[00] {/} [00]` or `[00] {.} [00]`, it causes a rendering error where it will add a second `/` or `.`.

This seems to be caused by `textInputDidChange` event causing it to re-evaluated text change in native code (this time in `RCTBackedTextInputDelegate`, causing a different output than that of `MaskedTextFieldDelegate`.

The solution is to instead not trigger `textInputDidChange` and instead just dispatch `onChange` event directly on `RCTBaseTextInputView` so that `TextInput.onTextChange` is triggered